### PR TITLE
XCMetricsBackendLib: Support build host, metadata and xcode version.

### DIFF
--- a/Sources/XCMetricsBackendLib/UploadMetrics/LogProcessing/LogParser.swift
+++ b/Sources/XCMetricsBackendLib/UploadMetrics/LogProcessing/LogParser.swift
@@ -43,47 +43,44 @@ struct LogParser {
 
     static func parseFromURL(
         _ url: URL,
+        metricsRequest: UploadMetricsRequest,
         machineName: String,
-        projectName: String,
         userId: String,
         userIdSHA256: String,
-        isCI: Bool,
-        sleepTime: Int?,
-        skipNotes: Bool?
+        isCI: Bool
     ) throws -> BuildMetrics {
         let activityLog = try ActivityParser().parseActivityLogInURL(url, redacted: true, withoutBuildSpecificInformation: true)
         let buildSteps = try ParserBuildSteps(machineName: machineName,
                                               omitWarningsDetails: false,
-                                              omitNotesDetails: skipNotes ?? false)
+                                              omitNotesDetails: metricsRequest.extraInfo.skipNotes ?? false)
             .parse(activityLog: activityLog)
             .flatten()
         return toBuildMetrics(
             buildSteps,
-            projectName: projectName,
+            metricsRequest: metricsRequest,
             userId: userId,
             userIdSHA256: userIdSHA256,
-            isCI: isCI,
-            sleepTime: sleepTime
+            isCI: isCI
         )
     }
 
     private static func toBuildMetrics(
         _ buildSteps: [BuildStep],
-        projectName: String,
+        metricsRequest: UploadMetricsRequest,
         userId: String,
         userIdSHA256: String,
-        isCI: Bool,
-        sleepTime: Int?
+        isCI: Bool
     ) -> BuildMetrics {
         let buildInfo: BuildStep = buildSteps[0]
+        let buildIdentifier = buildInfo.identifier
         var build = Build().withBuildStep(buildStep: buildInfo)
-        build.projectName = projectName
+        build.projectName = metricsRequest.extraInfo.projectName
         build.userid = userId
         build.userid256 = userIdSHA256
         build.tag = ""
         build.isCi = isCI
 
-        if let sleepTime = sleepTime {
+        if let sleepTime = metricsRequest.extraInfo.sleepTime {
             build.wasSuspended = Int64(round(buildInfo.startTimestamp)) < sleepTime
         } else {
             build.wasSuspended = false
@@ -97,10 +94,10 @@ struct LogParser {
 
         let detailsBuild = steps.filter { $0.detailStepType != .swiftCompilation }.map {
             return Step().withBuildStep(buildStep: $0,
-                                        buildIdentifier: buildSteps[0].identifier,
+                                        buildIdentifier: buildIdentifier,
                                         targetIdentifier: $0.parentIdentifier)
         }
-        var stepsBuild = detailsBuild + parseSwiftSteps(buildSteps: buildSteps, targets: targetBuildSteps, steps: steps)
+        var stepsBuild = detailsBuild + parseSwiftSteps(buildSteps: buildSteps, targets: targetBuildSteps, steps: steps, buildIdentifier: buildIdentifier)
 
         // Categorize build based on all build steps in the build log except non-compilation or linking phases.
         // Some tasks are ran by Xcode always, even on noop builds, so we want to filter them out and only
@@ -139,9 +136,9 @@ struct LogParser {
             return $0.targetIdentifier > $1.targetIdentifier
         }
 
-        let warnings = parseWarnings(buildSteps: buildSteps, targets: targetBuildSteps, steps: steps)
-        let errors = parseErrors(buildSteps: buildSteps, targets: targetBuildSteps, steps: steps)
-        let notes = parseNotes(buildSteps: buildSteps, targets: targetBuildSteps, steps: steps)
+        let warnings = parseWarnings(buildSteps: buildSteps, targets: targetBuildSteps, steps: steps, buildIdentifier: buildIdentifier)
+        let errors = parseErrors(buildSteps: buildSteps, targets: targetBuildSteps, steps: steps, buildIdentifier: buildIdentifier)
+        let notes = parseNotes(buildSteps: buildSteps, targets: targetBuildSteps, steps: steps, buildIdentifier: buildIdentifier)
 
         let functionBuildTimes = steps.compactMap { step in
             step.swiftFunctionTimes?.map {
@@ -169,18 +166,18 @@ struct LogParser {
                             notes: notes,
                             swiftFunctions: Array(functionBuildTimes),
                             swiftTypeChecks: Array(typeChecks),
-                            host: fakeHost(buildIdentifier: build.id ?? ""), // TODO
-                            xcodeVersion: nil, // TODO
-                            buildMetadata: nil) // TODO
+                            host: metricsRequest.buildHost.withBuildIdentifier(buildIdentifier),
+                            xcodeVersion: metricsRequest.xcodeVersion?.withBuildIdentifier(buildIdentifier),
+                            buildMetadata: metricsRequest.buildMetadata?.withBuildIdentifier(buildIdentifier))
                             .addDayToMetrics()
     }
 
     private static func parseSwiftSteps(
         buildSteps: [BuildStep],
         targets: [BuildStep],
-        steps: [BuildStep]
+        steps: [BuildStep],
+        buildIdentifier: String
     ) -> [Step] {
-        let buildIdentifier = buildSteps[0].identifier
         let swiftAggregatedSteps = buildSteps.filter { $0.type == .detail
             && $0.detailStepType == .swiftAggregatedCompilation }
 
@@ -265,9 +262,9 @@ struct LogParser {
     private static func parseWarnings(
         buildSteps: [BuildStep],
         targets: [BuildStep],
-        steps: [BuildStep]
+        steps: [BuildStep],
+        buildIdentifier: String
     ) -> [BuildWarning] {
-        let buildIdentifier = buildSteps[0].identifier
         let buildWarnings = buildSteps[0].warnings?.map {
             BuildWarning()
                 .withBuildIdentifier(buildIdentifier)
@@ -301,10 +298,9 @@ struct LogParser {
     private static func parseErrors(
         buildSteps: [BuildStep],
         targets: [BuildStep],
-        steps: [BuildStep]
+        steps: [BuildStep],
+        buildIdentifier: String
     ) -> [BuildError] {
-        let buildIdentifier = buildSteps[0].identifier
-
         let buildErrors = buildSteps[0].errors?.map {
             BuildError()
                 .withBuildIdentifier(buildIdentifier)
@@ -338,10 +334,9 @@ struct LogParser {
     private static func parseNotes(
         buildSteps: [BuildStep],
         targets: [BuildStep],
-        steps: [BuildStep]
+        steps: [BuildStep],
+        buildIdentifier: String
     ) -> [BuildNote] {
-        let buildIdentifier = buildSteps[0].identifier
-
         let buildNotes = buildSteps[0].notes?.map {
             BuildNote()
                 .withBuildIdentifier(buildIdentifier)
@@ -370,27 +365,5 @@ struct LogParser {
             }
         }.joined()
         return (buildNotes ?? []) + targetNotes + stepsNotes
-    }
-
-    private static func fakeHost(buildIdentifier: String) -> BuildHost {
-        let host = BuildHost()
-        host.buildIdentifier = buildIdentifier
-        host.cpuCount = 2
-        host.cpuModel = "model"
-        host.cpuSpeedGhz = 3.0
-        host.hostArchitecture = "x86"
-        host.hostModel = "model"
-        host.hostOs = "MacOS"
-        host.hostOsFamily = ""
-        host.hostOsVersion = ""
-        host.isVirtual = false
-        host.memoryFreeMb = 0.0
-        host.memoryTotalMb = 0.0
-        host.swapFreeMb = 0.0
-        host.swapTotalMb = 0.0
-        host.timezone = "CET"
-        host.uptimeSeconds = 0
-        return host
-
     }
 }

--- a/Sources/XCMetricsBackendLib/UploadMetrics/LogProcessing/MetricsProcessor.swift
+++ b/Sources/XCMetricsBackendLib/UploadMetrics/LogProcessing/MetricsProcessor.swift
@@ -12,13 +12,11 @@ struct MetricsProcessor {
         let isCI = metricsRequest.extraInfo.isCI
         return try LogParser.parseFromURL(
             logFile.localURL,
+            metricsRequest: metricsRequest,
             machineName: machineName,
-            projectName: metricsRequest.extraInfo.projectName,
             userId: userId,
             userIdSHA256: userIdSHA256,
-            isCI: isCI,
-            sleepTime: metricsRequest.extraInfo.sleepTime,
-            skipNotes: metricsRequest.extraInfo.skipNotes
+            isCI: isCI
         )
     }
 


### PR DESCRIPTION
The build metadata and xcode version were always set to `nil`, and the
build host was initialized with fake data.
Adding the real data was a matter of passing the data from
`metricsRequest`.
In addition, some refactoring was done to extract the build identifier
once.