### PR TITLE
XCMetrics: Support build tag.

### DIFF
--- a/Sources/XCMetricsBackendLib/UploadMetrics/LogProcessing/LogParser.swift
+++ b/Sources/XCMetricsBackendLib/UploadMetrics/LogProcessing/LogParser.swift
@@ -80,7 +80,7 @@ struct LogParser {
         build.projectName = projectName
         build.userid = userId
         build.userid256 = userIdSHA256
-        build.tag = ""
+        build.tag = metricsRequest.extraInfo.tag
         build.isCi = isCI
 
         if let sleepTime = sleepTime {

--- a/Sources/XCMetricsClient/Network/MultipartRequestBuilder.swift
+++ b/Sources/XCMetricsClient/Network/MultipartRequestBuilder.swift
@@ -85,11 +85,12 @@ class MultipartRequestBuilder {
         let user = MacOSUsernameReader().userID ?? "unknown"
         let sleepTime = HardwareFactsFetcherImplementation().sleepTime
         let extraInfo = UploadRequestExtraInfo(projectName: projectName,
-                                                machineName: machineName,
-                                                user: user,
-                                                isCI: isCI,
-                                                sleepTime: sleepTime,
-                                                skipNotes: skipNotes)
+                                               machineName: machineName,
+                                               user: user,
+                                               isCI: isCI,
+                                               sleepTime: sleepTime,
+                                               skipNotes: skipNotes,
+                                               tag: request.request.build.tag)
         let extraJson = try jsonEncoder.encode(extraInfo)
         if let extraData = toJSONFormField(named: "extraInfo", jsonData: extraJson, using: boundary) {
           httpBody.append(extraData)

--- a/Sources/XCMetricsCommon/UploadRequestExtraInfo.swift
+++ b/Sources/XCMetricsCommon/UploadRequestExtraInfo.swift
@@ -40,17 +40,22 @@ public final class UploadRequestExtraInfo: Codable {
     /// while providing little value
     public let skipNotes: Bool?
 
+    /// Build tag
+    public let tag: String
+
     public init(projectName: String,
                 machineName: String,
                 user: String,
                 isCI: Bool,
                 sleepTime: Int?,
-                skipNotes: Bool?) {
+                skipNotes: Bool?,
+                tag: String) {
         self.projectName = projectName
         self.machineName = machineName
         self.user = user
         self.isCI = isCI
         self.sleepTime = sleepTime
         self.skipNotes = skipNotes
+        self.tag = tag
     }
 }


### PR DESCRIPTION
Add build tag to `UploadRequestExtraInfo`.
I could have encoded the `Build` object and send it, but it would have
required extra boilerplate code and none of its other fields is used.